### PR TITLE
Add Teske woordjes 14 September (ruimte)

### DIFF
--- a/src/lib/data/teske-woordjes-20260914.json
+++ b/src/lib/data/teske-woordjes-20260914.json
@@ -1,0 +1,88 @@
+{
+	"name": "Teske woordjes 14 September",
+	"id": "c019a31d-68de-40a6-9b93-4f481aff37b1",
+	"for": "Teske",
+	"date": "2026-09-14",
+	"labels": { "word": "Nederlands", "translation": "Omschrijving" },
+	"words": [
+		{ "word": "uitdijen", "translation": "in omvang toenemen; groter worden" },
+		{ "word": "het universum", "translation": "het heelal" },
+		{
+			"word": "het voorstellingsvermogen",
+			"translation": "de mogelijkheid om iets voor je te kunnen zien"
+		},
+		{ "word": "zich verwonderen", "translation": "zich verbazen" },
+		{
+			"word": "de zwaartekracht",
+			"translation": "natuurkracht die als een magneet aan alles trekt"
+		},
+		{ "word": "de ruimtesonde", "translation": "ruimteschip zonder mensen erin" },
+		{
+			"word": "het ruimtestation",
+			"translation": "ruimteschip met mensen die erin wonen en werken"
+		},
+		{ "word": "het stelsel", "translation": "geordend geheel; netwerk" },
+		{
+			"word": "de sterrenwacht",
+			"translation": "gebouw met telescopen om de ruimte te bestuderen; observatorium"
+		},
+		{
+			"word": "de telescoop",
+			"translation": "grote verrekijker waarmee je in de ruimte kunt kijken"
+		},
+		{ "word": "nietig", "translation": "klein en niet belangrijk" },
+		{ "word": "onbemand", "translation": "zonder mensen/bemanning" },
+		{ "word": "oneindig", "translation": "zonder einde" },
+		{ "word": "overweldigend", "translation": "heel indrukwekkend" },
+		{
+			"word": "de ruimtemissie",
+			"translation": "bijzondere opdracht waarvoor je moet reizen in de ruimte"
+		},
+		{
+			"word": "het specialisme",
+			"translation": "onderwerp waar iemand veel van weet of heel goed in is"
+		},
+		{ "word": "het sterrenbeeld", "translation": "sterren die samen een figuur vormen" },
+		{
+			"word": "de testvlucht",
+			"translation": "reis van een vliegtuig of ruimtevaartuig om te testen of alles goed werkt"
+		},
+		{ "word": "de zee van sterren", "translation": "enorme hoeveelheid zichtbare sterren" },
+		{
+			"word": "zich baseren op",
+			"translation": "aan de hand van bepaalde informatie je mening of conclusie vormen"
+		},
+		{ "word": "met het blote oog", "translation": "iets kunnen zien zonder hulpmiddelen" },
+		{ "word": "het object", "translation": "het voorwerp" },
+		{ "word": "de passie", "translation": "intens enthousiasme voor iets" },
+		{ "word": "de pionier", "translation": "iemand die als eerste iets doet; baanbreker" },
+		{ "word": "de research", "translation": "het onderzoek" },
+		{
+			"word": "het doorzettingsvermogen",
+			"translation": "de eigenschap waarmee je volhoudt om je doel te bereiken"
+		},
+		{ "word": "experimenteren", "translation": "iets uitproberen; ergens proeven mee doen" },
+		{
+			"word": "het fenomeen",
+			"translation": "opvallend verschijnsel; vaak een natuurverschijnsel"
+		},
+		{ "word": "het hemellichaam", "translation": "iets wat van nature voorkomt in het heelal" },
+		{ "word": "de ingenieur", "translation": "de technicus" },
+		{
+			"word": "de astronomie",
+			"translation": "sterrenkunde; natuurwetenschap die zich bezighoudt met het heelal"
+		},
+		{ "word": "astronomisch", "translation": "gigantisch" },
+		{
+			"word": "de astronoom",
+			"translation": "sterrenkundige; wetenschapper die het heelal bestudeert"
+		},
+		{ "word": "boeien", "translation": "iemands aandacht vasthouden" },
+		{ "word": "de carrière", "translation": "loopbaan; het werk dat je doet" },
+		{ "word": "denkbeeldig", "translation": "bedacht, tegenovergestelde van werkelijk" },
+		{ "word": "gewichtloos", "translation": "zonder gewicht" },
+		{ "word": "immens", "translation": "heel groot; onmetelijk" },
+		{ "word": "lanceren", "translation": "de lucht in laten gaan" },
+		{ "word": "het lichtjaar", "translation": "afstand die het licht in één jaar aflegt" }
+	]
+}


### PR DESCRIPTION
## Summary
- Add a new Dutch wordlist `src/lib/data/teske-woordjes-20260914.json` for Teske, dated 2026-09-14, covering the "ruimte" (space) theme (40 word/omschrijving pairs)
- Wordlist is picked up automatically via the existing `import.meta.glob` in `WordListManager.ts`, including the auto-generated reverse variant

## Test plan
- [x] Validated JSON syntax
- [x] Formatted with `prettier`
- [x] `npx vitest run` on `WordList`/`WordPair` specs passes
- [x] `npm run build` succeeds and the new list ("Teske woordjes 14 September") appears in the prerendered output


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt7qhWoeVxedPGk2sDMKhV)_